### PR TITLE
Bugfix: histogram of pictures with all pixels of the same value

### DIFF
--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -492,7 +492,7 @@ class ImageItem(GraphicsObject):
                 return None, None
             if stepData.dtype.kind in "ui":
                 # For integer data, we select the bins carefully to avoid aliasing
-                step = np.ceil((mx-mn) / 500.)
+                step = np.ceil((mx-mn) / 500.) if not (mx-mn) == 0 else 1
                 bins = np.arange(mn, mx+1.01*step, step, dtype=np.int)
             else:
                 # for float data, let numpy select the bins.


### PR DESCRIPTION
When mx == mn the following Exception is thrown:
"pyqtgraph\graphicsItems\ImageItem.py", line 497, in getHistogram
    bins = np.arange(mn, mx+1.01*step, step, dtype=np.int)
ValueError: arange: cannot compute length

Fixed by handling this edge case.